### PR TITLE
Reset GameRunner execution flag on tick errors

### DIFF
--- a/src/core/GameRunner.ts
+++ b/src/core/GameRunner.ts
@@ -139,6 +139,7 @@ export class GameRunner {
       } else {
         console.error("Game tick error:", error);
       }
+      this.isExecuting = false;
       return;
     }
 


### PR DESCRIPTION
## Summary
- ensure `GameRunner` clears its execution guard when a tick throws so processing can continue after handling the error

## Testing
- npm test -- --runTestsByPath tests/core/game/GameImpl.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cedde22c7483208af6022bf0d860f3